### PR TITLE
contrib: bhatti-routes — preview subdomain routing tool

### DIFF
--- a/contrib/bhatti-routes/README.md
+++ b/contrib/bhatti-routes/README.md
@@ -1,0 +1,197 @@
+# bhatti-routes
+
+Preview subdomain routing for bhatti sandboxes. Expose sandbox services as HTTPS URLs like `https://myapp.dev2.example.com`.
+
+## How it works
+
+```
+Browser → Caddy (:443, auto-TLS) → VM bridge IP directly → sandbox service
+```
+
+- **Direct-to-VM routing** — Caddy proxies straight to the Firecracker VM's bridge IP. No double-proxy, no buffering issues.
+- **Auto-TLS** — Let's Encrypt certificates via Cloudflare DNS-01 challenge.
+- **Auto-wake** — A route-gen script runs every 15s, keeping routed sandboxes warm by pinging bhatti's API. Cold VMs restore in ~50ms on next cycle.
+- **Multi-port** — Expose multiple ports from the same sandbox on different subdomains.
+
+## Prerequisites
+
+- bhatti installed and running
+- [Caddy](https://caddyserver.com/) with the [cloudflare DNS plugin](https://github.com/caddy-dns/cloudflare) (for wildcard TLS)
+- [uv](https://docs.astral.sh/uv/) (for the CLI script)
+- Cloudflare-managed domain (optional, for auto DNS record management)
+
+## Quick start
+
+### 1. Install Caddy with Cloudflare plugin
+
+```bash
+go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+xcaddy build --with github.com/caddy-dns/cloudflare --output /usr/local/bin/caddy
+```
+
+### 2. Set up config directory
+
+```bash
+sudo mkdir -p /opt/bhatti-caddy
+sudo touch /opt/bhatti-caddy/routes.yml /opt/bhatti-caddy/sites.caddy
+
+sudo tee /opt/bhatti-caddy/Caddyfile > /dev/null <<EOF
+{
+    acme_dns cloudflare {env.CF_DNS_API_TOKEN}
+    email admin@example.com
+}
+
+import /opt/bhatti-caddy/sites.caddy
+EOF
+```
+
+### 3. Install scripts
+
+```bash
+sudo cp bhatti-routes /usr/local/bin/bhatti-routes
+sudo cp route-gen.sh /opt/bhatti-caddy/route-gen.sh
+```
+
+### 4. Configure environment
+
+Set these in your shell profile or systemd unit:
+
+```bash
+export BHATTI_DOMAIN="dev2.example.com"       # subdomain suffix
+export BHATTI_PUBLIC_IP="1.2.3.4"             # IP for DNS A records
+export CF_DNS_API_TOKEN="your_token"          # Cloudflare API token
+export BHATTI_CF_ZONE_ID="your_zone_id"       # Cloudflare zone ID (optional)
+```
+
+### 5. Start Caddy + route timer
+
+```bash
+# Caddy service
+sudo systemctl enable --now caddy-bhatti
+
+# Route-gen timer (runs every 15s)
+sudo systemctl enable --now bhatti-routes.timer
+```
+
+See [systemd/](systemd/) for example unit files, or create them:
+
+```ini
+# /etc/systemd/system/caddy-bhatti.service
+[Unit]
+Description=Caddy for bhatti preview subdomains
+After=network.target bhatti.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/caddy run --config /opt/bhatti-caddy/Caddyfile
+ExecReload=/usr/local/bin/caddy reload --config /opt/bhatti-caddy/Caddyfile
+Environment=CF_DNS_API_TOKEN=your_token
+Restart=always
+LimitNOFILE=65536
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```ini
+# /etc/systemd/system/bhatti-routes.service
+[Unit]
+Description=Generate Caddy routes from bhatti sandboxes
+After=bhatti.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bhatti-caddy/route-gen.sh
+Environment=CF_DNS_API_TOKEN=your_token
+Environment=BHATTI_DOMAIN=dev2.example.com
+Environment=BHATTI_PUBLIC_IP=1.2.3.4
+Environment=BHATTI_CF_ZONE_ID=your_zone_id
+```
+
+```ini
+# /etc/systemd/system/bhatti-routes.timer
+[Unit]
+Description=Refresh bhatti Caddy routes every 15s
+
+[Timer]
+OnBootSec=10s
+OnUnitActiveSec=15s
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target
+```
+
+## Usage
+
+```bash
+# Expose a sandbox port
+bhatti-routes add myapp 3000
+# → https://myapp.dev2.example.com
+
+# Expose another port on a custom subdomain
+bhatti-routes add myapp 8080 myapp-api
+# → https://myapp-api.dev2.example.com
+
+# Interactive port picker (scans sandbox, shows process info)
+bhatti-routes pick myapp
+
+# List all active routes
+bhatti-routes ls
+# ┏━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+# ┃ Subdomain  ┃ Sandbox ┃ Port ┃ URL                                 ┃
+# ┡━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+# │ myapp      │ myapp   │ 3000 │ https://myapp.dev2.example.com      │
+# │ myapp-api  │ myapp   │ 8080 │ https://myapp-api.dev2.example.com  │
+# └────────────┴─────────┴──────┴─────────────────────────────────────┘
+
+# Show listening ports with process/container details
+bhatti-routes ports myapp
+# ┏━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+# ┃ # ┃ Port ┃ Process                                       ┃
+# ┡━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+# │ 1 │ 3000 │ workspace-ui-1 (workspace-ui)                 │
+# │ 2 │ 8080 │ workspace-api-1 (workspace-api)               │
+# │ 3 │ 5432 │ workspace-postgres-1 (pgvector)               │
+# └───┴──────┴───────────────────────────────────────────────┘
+
+# Remove a route
+bhatti-routes rm myapp-api
+
+# Force-sync Caddy config + DNS
+bhatti-routes sync
+```
+
+## Architecture
+
+```
+bhatti-routes CLI ──writes──→ routes.yml
+                                  │
+route-gen.sh (15s timer) ─reads───┘
+    │
+    ├── Looks up sandbox bridge IPs via bhatti API
+    ├── Pings GET /sandboxes/:id to keep VMs warm
+    ├── Creates Cloudflare DNS A records (if configured)
+    ├── Generates Caddy site blocks → sites.caddy
+    └── Reloads Caddy
+```
+
+### Why direct-to-VM instead of bhatti's proxy?
+
+Bhatti's built-in reverse proxy (`/sandboxes/:id/proxy/:port/`) routes through a raw TCP tunnel. When an upstream HTTP proxy (Caddy/Traefik) is the client, responses larger than ~2KB can hang indefinitely due to a buffering interaction between `httputil.ReverseProxy` and the tunnel's `io.Copy`. Direct-to-VM-bridge-IP routing avoids this entirely.
+
+### Why a timer instead of on-demand wake?
+
+When a routed VM is cold (snapshotted to disk after 30min idle), its bridge IP isn't reachable. The 15s timer keeps routed VMs warm by calling bhatti's API, which triggers `ensureHot()`. This is simpler than implementing a Caddy middleware for on-demand wake, and the worst-case latency is 15s + 50ms (cold restore time).
+
+## Routes file format
+
+```yaml
+# subdomain: sandbox:port
+myapp: myapp:3000
+myapp-api: myapp:8080
+
+# shorthand (subdomain = sandbox name)
+demo: 8000
+```

--- a/contrib/bhatti-routes/bhatti-routes
+++ b/contrib/bhatti-routes/bhatti-routes
@@ -1,0 +1,334 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["httpx", "rich", "InquirerPy"]
+# ///
+"""
+bhatti-routes — Preview subdomain routing for bhatti sandboxes.
+
+Manages Caddy reverse proxy routes that expose sandbox services as
+HTTPS subdomains (e.g., https://myapp.dev2.example.com).
+
+Routes directly to VM bridge IPs for zero-overhead proxying.
+A companion route-gen script keeps routed sandboxes warm and
+generates Caddy config + DNS records.
+
+Requires: uv (https://docs.astral.sh/uv/), bhatti CLI configured.
+"""
+
+import os
+import sys
+import re
+import subprocess
+from pathlib import Path
+
+import httpx
+from rich.console import Console
+from rich.table import Table
+from InquirerPy import inquirer
+
+ROUTES_FILE = Path(os.environ.get("BHATTI_ROUTES_FILE", "/opt/bhatti-caddy/routes.yml"))
+ROUTE_GEN = os.environ.get("BHATTI_ROUTE_GEN", "/opt/bhatti-caddy/route-gen.sh")
+DOMAIN = os.environ.get("BHATTI_DOMAIN", "dev2.example.com")
+BHATTI_CMD = os.environ.get("BHATTI_CMD", "bhatti")
+AGENT_PORTS = {"1024", "1025"}
+
+console = Console()
+
+
+# --- Routes file I/O ---
+# Format: subdomain: sandbox:port
+# Backward-compatible: subdomain: port (sandbox = subdomain)
+
+def read_routes() -> list[tuple[str, str, str]]:
+    if not ROUTES_FILE.exists():
+        return []
+    routes = []
+    for line in ROUTES_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        subdomain, _, rest = line.partition(":")
+        subdomain = subdomain.strip()
+        rest = rest.strip()
+        if ":" in rest:
+            sandbox, _, port = rest.partition(":")
+        else:
+            sandbox, port = subdomain, rest
+        routes.append((subdomain.strip(), sandbox.strip(), port.strip()))
+    return routes
+
+
+def write_routes(routes: list[tuple[str, str, str]]):
+    lines = [f"{sub}: {sb}:{port}" for sub, sb, port in routes]
+    ROUTES_FILE.write_text("\n".join(lines) + "\n" if lines else "")
+
+
+def sync():
+    subprocess.run(["sudo", ROUTE_GEN], check=True)
+
+
+# --- Port scanning ---
+
+def get_docker_port_map(sandbox: str) -> dict[str, str]:
+    result = subprocess.run(
+        [BHATTI_CMD, "exec", sandbox, "--", "sudo", "docker", "ps",
+         "--format", "{{.Names}}\t{{.Image}}\t{{.Ports}}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return {}
+
+    port_map: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        name, image, ports_str = parts[0], parts[1], parts[2]
+        image_short = image.split("/")[-1].split(":")[0]
+        label = f"{name} ({image_short})"
+        for segment in ports_str.split(","):
+            segment = segment.strip()
+            range_match = re.search(r"(?:0\.0\.0\.0|::):(\d+)-(\d+)->", segment)
+            if range_match:
+                for p in range(int(range_match.group(1)), int(range_match.group(2)) + 1):
+                    port_map[str(p)] = label
+                continue
+            single_match = re.search(r"(?:0\.0\.0\.0|::):(\d+)->", segment)
+            if single_match:
+                port_map[single_match.group(1)] = label
+    return port_map
+
+
+def get_listening_ports(sandbox: str) -> list[dict]:
+    docker_map = get_docker_port_map(sandbox)
+
+    result = subprocess.run(
+        [BHATTI_CMD, "exec", sandbox, "--", "sudo", "ss", "-tlnp"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        console.print(f"[red]Cannot reach sandbox '{sandbox}'[/red]")
+        sys.exit(1)
+
+    ports = []
+    seen = set()
+    for line in result.stdout.splitlines():
+        if line.startswith("State"):
+            continue
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        addr = parts[3]
+        match = re.search(r":(\d+)$", addr)
+        if not match:
+            continue
+        port = match.group(1)
+        if port in AGENT_PORTS or port in seen:
+            continue
+        seen.add(port)
+
+        if port in docker_map:
+            proc = docker_map[port]
+        else:
+            proc_match = re.search(r'users:\(\("([^"]+)"', line)
+            proc = proc_match.group(1) if proc_match else "-"
+
+        ports.append({"port": port, "process": proc})
+
+    return ports
+
+
+# --- Commands ---
+
+def cmd_add(args: list[str]):
+    if len(args) < 2:
+        console.print("Usage: bhatti-routes add <sandbox> <port> [subdomain]")
+        sys.exit(1)
+
+    sandbox, port = args[0], args[1]
+    subdomain = args[2] if len(args) > 2 else sandbox
+
+    routes = read_routes()
+    routes = [(s, sb, p) for s, sb, p in routes if s != subdomain]
+    routes.append((subdomain, sandbox, port))
+    write_routes(routes)
+
+    sync()
+    console.print(f"[green]https://{subdomain}.{DOMAIN}[/green] → {sandbox}:{port}")
+
+
+def cmd_rm(args: list[str]):
+    if not args:
+        console.print("Usage: bhatti-routes rm <subdomain>")
+        sys.exit(1)
+
+    subdomain = args[0]
+    routes = read_routes()
+    new_routes = [(s, sb, p) for s, sb, p in routes if s != subdomain]
+
+    if len(new_routes) == len(routes):
+        console.print(f"[red]No route for '{subdomain}'[/red]")
+        sys.exit(1)
+
+    write_routes(new_routes)
+    sync()
+    console.print(f"Removed: {subdomain}")
+
+
+def cmd_ls(_args: list[str]):
+    routes = read_routes()
+    if not routes:
+        console.print("No routes configured")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Subdomain", style="cyan")
+    table.add_column("Sandbox")
+    table.add_column("Port", justify="right")
+    table.add_column("URL", style="green")
+
+    for subdomain, sandbox, port in routes:
+        table.add_row(subdomain, sandbox, port, f"https://{subdomain}.{DOMAIN}")
+
+    console.print(table)
+
+
+def cmd_ports(args: list[str]):
+    if not args:
+        console.print("Usage: bhatti-routes ports <sandbox>")
+        sys.exit(1)
+
+    sandbox = args[0]
+    ports = get_listening_ports(sandbox)
+
+    if not ports:
+        console.print(f"No listening ports in '{sandbox}'")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("#", justify="right")
+    table.add_column("Port", justify="right", style="cyan")
+    table.add_column("Process")
+
+    for i, p in enumerate(ports, 1):
+        table.add_row(str(i), p["port"], p["process"])
+
+    console.print(table)
+
+
+def cmd_pick(args: list[str]):
+    if not args:
+        console.print("Usage: bhatti-routes pick <sandbox>")
+        sys.exit(1)
+
+    sandbox = args[0]
+    console.print(f"Scanning ports on [bold]{sandbox}[/bold]...\n")
+
+    ports = get_listening_ports(sandbox)
+    if not ports:
+        console.print(f"[red]No listening ports in '{sandbox}'[/red]")
+        return
+
+    routes = read_routes()
+
+    has_bindings = any(
+        sb == sandbox for _, sb, _ in routes
+    )
+
+    if has_bindings:
+        console.print("[bold]Already exposed:[/bold]")
+        for p in ports:
+            bound = [(sub, sb) for sub, sb, pt in routes if sb == sandbox and pt == p["port"]]
+            for sub, _ in bound:
+                console.print(f"  :{p['port']} ({p['process']}) → [green]https://{sub}.{DOMAIN}[/green]")
+        console.print()
+        console.print("[dim]A port can be exposed on multiple subdomains — just pick a unique subdomain name.[/dim]\n")
+
+    choices = [
+        {"name": f":{p['port']}  {p['process']}", "value": p["port"]}
+        for p in ports
+    ]
+
+    console.print("[dim]↑/↓ navigate  ·  space select  ·  enter confirm[/dim]\n")
+
+    selected = inquirer.checkbox(
+        message="Select ports to expose",
+        choices=choices,
+    ).execute()
+
+    if not selected:
+        console.print("Nothing selected")
+        return
+
+    added = []
+    for port in selected:
+        proc = next((p["process"] for p in ports if p["port"] == port), "-")
+
+        bound_subs = [sub for sub, sb, pt in routes if sb == sandbox and pt == port]
+        default_sub = sandbox if len(selected) == 1 and not bound_subs else f"{sandbox}-{port}"
+
+        if bound_subs:
+            console.print(f"[dim]  :{port} already exposed as: {', '.join(bound_subs)}[/dim]")
+
+        subdomain = inquirer.text(
+            message=f"Subdomain for :{port} ({proc})",
+            default=default_sub,
+        ).execute()
+
+        if not subdomain:
+            continue
+
+        routes = [(s, sb, p) for s, sb, p in routes if s != subdomain]
+        routes.append((subdomain, sandbox, port))
+        added.append((subdomain, port))
+
+    if not added:
+        console.print("Nothing added")
+        return
+
+    write_routes(routes)
+    sync()
+
+    console.print()
+    for subdomain, port in added:
+        console.print(f"  [green]https://{subdomain}.{DOMAIN}[/green] → {sandbox}:{port}")
+
+
+def cmd_sync(_args: list[str]):
+    sync()
+
+
+COMMANDS = {
+    "add": cmd_add,
+    "rm": cmd_rm,
+    "ls": cmd_ls,
+    "ports": cmd_ports,
+    "pick": cmd_pick,
+    "sync": cmd_sync,
+}
+
+if len(sys.argv) < 2 or sys.argv[1] not in COMMANDS:
+    console.print(f"""[bold]bhatti-routes[/bold] — manage preview subdomain routes
+
+[bold]Commands:[/bold]
+  [cyan]add[/cyan]  <sandbox> <port> [subdomain]   Expose a port as https://<subdomain>.{DOMAIN}
+  [cyan]rm[/cyan]   <subdomain>                    Remove a route
+  [cyan]ls[/cyan]                                  List active routes
+  [cyan]ports[/cyan] <sandbox>                     Show listening ports with process info
+  [cyan]pick[/cyan]  <sandbox>                     Interactive port picker
+  [cyan]sync[/cyan]                                Regenerate Caddy config + DNS
+
+[bold]Examples:[/bold]
+  bhatti-routes add myapp 3000                  → https://myapp.{DOMAIN}
+  bhatti-routes add myapp 8080 myapp-api        → https://myapp-api.{DOMAIN}
+  bhatti-routes pick myapp                      → interactive selector
+
+[bold]Environment:[/bold]
+  BHATTI_DOMAIN         Base domain (default: dev2.example.com)
+  BHATTI_ROUTES_FILE    Routes file path (default: /opt/bhatti-caddy/routes.yml)
+  BHATTI_ROUTE_GEN      Route-gen script path (default: /opt/bhatti-caddy/route-gen.sh)
+  BHATTI_CMD            Bhatti CLI binary (default: bhatti)""")
+    sys.exit(1 if len(sys.argv) > 1 else 0)
+
+COMMANDS[sys.argv[1]](sys.argv[2:])

--- a/contrib/bhatti-routes/route-gen.sh
+++ b/contrib/bhatti-routes/route-gen.sh
@@ -1,33 +1,24 @@
 #!/bin/bash
-# route-gen.sh — Generates Caddy site config + Cloudflare DNS records from routes.yml
-#
-# Run periodically (e.g., systemd timer every 15s) to:
-#   1. Keep routed sandboxes warm (prevents cold VM 502s)
-#   2. Sync Caddy config with current sandbox IPs
-#   3. Ensure DNS records exist
-#
-# Configuration via environment or edit the variables below.
 set -euo pipefail
 
-ROUTES_FILE="${BHATTI_ROUTES_FILE:-/opt/bhatti-caddy/routes.yml}"
-OUTPUT_FILE="${BHATTI_SITES_FILE:-/opt/bhatti-caddy/sites.caddy}"
-DOMAIN="${BHATTI_DOMAIN:-dev2.example.com}"
-PUBLIC_IP="${BHATTI_PUBLIC_IP:-127.0.0.1}"
-BHATTI_URL="${BHATTI_URL:-http://localhost:8080}"
-CADDY_CONFIG="${BHATTI_CADDY_CONFIG:-/opt/bhatti-caddy/Caddyfile}"
+ROUTES_FILE="/opt/bhatti-caddy/routes.yml"
+OUTPUT_FILE="/opt/bhatti-caddy/sites.caddy"
+DOMAIN="dev2.ctxmill.com"
+PUBLIC_IP="100.72.221.54"
+BHATTI_URL="http://localhost:8080"
 
 BHATTI_TOKEN="${BHATTI_TOKEN:-$(grep auth_token /root/.bhatti/config.yaml 2>/dev/null | awk '{print $2}' || echo '')}"
 CF_TOKEN="${CF_DNS_API_TOKEN:-}"
-CF_ZONE_ID="${BHATTI_CF_ZONE_ID:-}"
+CF_ZONE_ID="ccd005bbeca3ab5e58af32b4f7308273"
 
 if [[ -z "$BHATTI_TOKEN" ]]; then
-    echo "error: BHATTI_TOKEN not set and not found in config" >&2
+    echo "error: BHATTI_TOKEN not set" >&2
     exit 1
 fi
 
 ensure_dns_record() {
     local name="$1"
-    [[ -z "$CF_TOKEN" || -z "$CF_ZONE_ID" ]] && return 0
+    [[ -z "$CF_TOKEN" ]] && return 0
     local existing
     existing=$(curl -sf -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
         "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records?type=A&name=$name" \
@@ -49,12 +40,7 @@ get_sandbox_info() {
         | jq -r ".[] | select(.name == \"$name\") | \"\(.id) \(.ip)\""
 }
 
-wake_sandbox() {
-    local sandbox_id="$1"
-    curl -sf -H "Authorization: Bearer $BHATTI_TOKEN" "$BHATTI_URL/sandboxes/$sandbox_id" > /dev/null 2>&1 || true
-}
 
-# Parse routes (format: subdomain: sandbox:port OR subdomain: port)
 declare -A SUBDOMAINS SANDBOXES PORTS
 route_count=0
 while IFS=: read -r subdomain rest; do
@@ -102,10 +88,12 @@ fi
         ensure_dns_record "$subdomain.$DOMAIN"
         ensure_dns_record "*.$subdomain.$DOMAIN"
 
-        wake_sandbox "$sandbox_id"
-
         cat << SITE
 ${subdomain}.${DOMAIN}, *.${subdomain}.${DOMAIN} {
+	forward_auth ${BHATTI_URL} {
+		uri /sandboxes/${sandbox_id}
+		header_up Authorization "Bearer ${BHATTI_TOKEN}"
+	}
 	reverse_proxy ${sandbox_ip}:${port}
 }
 
@@ -116,4 +104,4 @@ SITE
 mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
 echo "Written $OUTPUT_FILE ($route_count routes)" >&2
 
-caddy reload --config "$CADDY_CONFIG" 2>/dev/null || true
+caddy reload --config /opt/bhatti-caddy/Caddyfile 2>/dev/null || true

--- a/contrib/bhatti-routes/route-gen.sh
+++ b/contrib/bhatti-routes/route-gen.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# route-gen.sh — Generates Caddy site config + Cloudflare DNS records from routes.yml
+#
+# Run periodically (e.g., systemd timer every 15s) to:
+#   1. Keep routed sandboxes warm (prevents cold VM 502s)
+#   2. Sync Caddy config with current sandbox IPs
+#   3. Ensure DNS records exist
+#
+# Configuration via environment or edit the variables below.
+set -euo pipefail
+
+ROUTES_FILE="${BHATTI_ROUTES_FILE:-/opt/bhatti-caddy/routes.yml}"
+OUTPUT_FILE="${BHATTI_SITES_FILE:-/opt/bhatti-caddy/sites.caddy}"
+DOMAIN="${BHATTI_DOMAIN:-dev2.example.com}"
+PUBLIC_IP="${BHATTI_PUBLIC_IP:-127.0.0.1}"
+BHATTI_URL="${BHATTI_URL:-http://localhost:8080}"
+CADDY_CONFIG="${BHATTI_CADDY_CONFIG:-/opt/bhatti-caddy/Caddyfile}"
+
+BHATTI_TOKEN="${BHATTI_TOKEN:-$(grep auth_token /root/.bhatti/config.yaml 2>/dev/null | awk '{print $2}' || echo '')}"
+CF_TOKEN="${CF_DNS_API_TOKEN:-}"
+CF_ZONE_ID="${BHATTI_CF_ZONE_ID:-}"
+
+if [[ -z "$BHATTI_TOKEN" ]]; then
+    echo "error: BHATTI_TOKEN not set and not found in config" >&2
+    exit 1
+fi
+
+ensure_dns_record() {
+    local name="$1"
+    [[ -z "$CF_TOKEN" || -z "$CF_ZONE_ID" ]] && return 0
+    local existing
+    existing=$(curl -sf -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+        "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records?type=A&name=$name" \
+        | jq -r '.result[0].id // empty') || true
+    if [[ -n "$existing" ]]; then
+        curl -sf -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+            -X PUT "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$existing" \
+            -d "{\"type\":\"A\",\"name\":\"$name\",\"content\":\"$PUBLIC_IP\",\"ttl\":300,\"proxied\":false}" > /dev/null || true
+    else
+        curl -sf -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
+            -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" \
+            -d "{\"type\":\"A\",\"name\":\"$name\",\"content\":\"$PUBLIC_IP\",\"ttl\":300,\"proxied\":false}" > /dev/null || true
+    fi
+}
+
+get_sandbox_info() {
+    local name="$1"
+    curl -sf -H "Authorization: Bearer $BHATTI_TOKEN" "$BHATTI_URL/sandboxes" \
+        | jq -r ".[] | select(.name == \"$name\") | \"\(.id) \(.ip)\""
+}
+
+wake_sandbox() {
+    local sandbox_id="$1"
+    curl -sf -H "Authorization: Bearer $BHATTI_TOKEN" "$BHATTI_URL/sandboxes/$sandbox_id" > /dev/null 2>&1 || true
+}
+
+# Parse routes (format: subdomain: sandbox:port OR subdomain: port)
+declare -A SUBDOMAINS SANDBOXES PORTS
+route_count=0
+while IFS=: read -r subdomain rest; do
+    subdomain=$(echo "$subdomain" | xargs)
+    rest=$(echo "$rest" | xargs)
+    [[ -z "$subdomain" || "$subdomain" == \#* ]] && continue
+    if [[ "$rest" == *:* ]]; then
+        sandbox="${rest%%:*}"
+        port="${rest##*:}"
+    else
+        sandbox="$subdomain"
+        port="$rest"
+    fi
+    sandbox=$(echo "$sandbox" | xargs)
+    port=$(echo "$port" | xargs)
+    SUBDOMAINS[$route_count]="$subdomain"
+    SANDBOXES[$route_count]="$sandbox"
+    PORTS[$route_count]="$port"
+    route_count=$((route_count + 1))
+done < "$ROUTES_FILE"
+
+if [[ $route_count -eq 0 ]]; then
+    echo "# No routes" > "$OUTPUT_FILE"
+    echo "No routes in $ROUTES_FILE"
+    exit 0
+fi
+
+{
+    for ((i=0; i<route_count; i++)); do
+        subdomain="${SUBDOMAINS[$i]}"
+        sandbox="${SANDBOXES[$i]}"
+        port="${PORTS[$i]}"
+        info=$(get_sandbox_info "$sandbox")
+
+        if [[ -z "$info" ]]; then
+            echo "  SKIP: sandbox '$sandbox' not found (subdomain: $subdomain)" >&2
+            continue
+        fi
+
+        sandbox_id=$(echo "$info" | awk '{print $1}')
+        sandbox_ip=$(echo "$info" | awk '{print $2}')
+
+        echo "Route: $subdomain.$DOMAIN -> $sandbox_ip:$port ($sandbox)" >&2
+
+        ensure_dns_record "$subdomain.$DOMAIN"
+        ensure_dns_record "*.$subdomain.$DOMAIN"
+
+        wake_sandbox "$sandbox_id"
+
+        cat << SITE
+${subdomain}.${DOMAIN}, *.${subdomain}.${DOMAIN} {
+	reverse_proxy ${sandbox_ip}:${port}
+}
+
+SITE
+    done
+} > "${OUTPUT_FILE}.tmp"
+
+mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
+echo "Written $OUTPUT_FILE ($route_count routes)" >&2
+
+caddy reload --config "$CADDY_CONFIG" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Adds `contrib/bhatti-routes/` — a self-contained CLI + route-gen script for exposing sandbox services as HTTPS preview subdomains
- Implements **Option A** from #1 (companion tool pattern)
- Zero changes to bhatti core

## What's included

| File | Purpose |
|---|---|
| `bhatti-routes` | Python/uv CLI — `add`, `rm`, `ls`, `ports`, `pick` commands |
| `route-gen.sh` | Generates Caddy site config + Cloudflare DNS records, keeps VMs warm |
| `README.md` | Setup guide, architecture docs, usage examples |

## How it works

```
bhatti-routes add myapp 3000        → https://myapp.dev2.example.com
bhatti-routes add myapp 8080 api    → https://api.dev2.example.com
bhatti-routes pick myapp            → interactive port selector
```

Routes directly to VM bridge IPs via Caddy (not through bhatti's proxy — see #1 for the buffering issue with >2KB responses). A 15s timer runs `route-gen.sh` to keep routed VMs warm and sync Caddy config.

## Key features

- **Multi-port per sandbox**: Same sandbox on multiple subdomains (`myapp.example.com` + `api.example.com`)
- **Interactive picker** (`pick`): Scans listening ports, shows Docker container names + images, checkbox selection with `InquirerPy`
- **Docker-aware port scanning**: Resolves `docker-proxy` PIDs to actual container name + image
- **Auto-DNS**: Creates Cloudflare A records per route (optional, env-configured)
- **Auto-TLS**: Caddy handles Let's Encrypt via Cloudflare DNS-01 challenge
- **Auto-wake**: Timer pings routed sandboxes every 15s via bhatti API (`ensureHot`)

## Dependencies

- [uv](https://docs.astral.sh/uv/) for the CLI (self-contained script, deps in inline metadata)
- [Caddy](https://caddyserver.com/) with [cloudflare DNS plugin](https://github.com/caddy-dns/cloudflare) for reverse proxy + TLS
- Cloudflare-managed domain (optional, for auto DNS)

## Testing

Tested in production on a GCP VM running bhatti v0.4.1 with 5 sandboxes and multiple exposed ports per sandbox. Works with both bare-metal services and Docker Compose stacks inside sandboxes.

Closes #1 (Option A).